### PR TITLE
Fix Composer Autoloader can't find class

### DIFF
--- a/dice.php
+++ b/dice.php
@@ -35,7 +35,7 @@ class Dice {
 		if (!$forceNewInstance && isset($this->instances[strtolower($component)])) return $this->instances[strtolower($component)];
 		
 		$rule = $this->getRule($component);
-		$className = (!empty($rule->instanceOf)) ? strtolower($rule->instanceOf) : $component;		
+		$className = (!empty($rule->instanceOf)) ? $rule->instanceOf : $component;		
 		$share = $this->getParams($rule->shareInstances);		
 		$params = $this->getMethodParams($className, '__construct', $rule, array_merge($share, $args, $this->getParams($rule->constructParams)), $share);
 		


### PR DESCRIPTION
I got an error below:

```
Class twig_loader_filesystem does not exist
```

The true class name is `Twig_Loader_Filesystem` and located in `vendor/twig/twig/lib/Twig/Loader/Filesystem.php`.

My code is below:

``` php
        $rule1 = new \DiceRule;
        $rule1->instanceOf = 'Twig_Loader_Filesystem';
        $rule1->constructParams = [__DIR__ . '/../app/views'];
        $container->addRule('$MyTwig_Loader_Filesystem', $rule1); 

        $rule2 = new \DiceRule;
        $rule2->shared = true;
        $rule2->constructParams = [['cache' => __DIR__ . '/../cache']];
        $rule2->substitutions['Twig_LoaderInterface'] = new \DiceInstance('$MyTwig_Loader_Filesystem');
        $container->addRule('Twig_Environment', $rule2);
```
