### PR TITLE
Small fixes to the immutable implementation

### DIFF
--- a/Dice.php
+++ b/Dice.php
@@ -31,9 +31,6 @@ class Dice {
 	 * @param array $rule The container can be fully configured using rules provided by associative arrays. See {@link https://r.je/dice.html#example3} for a description of the rules.
 	 */
 	public function addRule(string $name, array $rule): self {
-		//Clear any existing instance or cache for this class
-		unset($this->instances[$name], $this->cache[$name]);
-
 		if (isset($rule['instanceOf']) && (!array_key_exists('inherit', $rule) || $rule['inherit'] === true )) {
 			$rule = array_replace_recursive($this->getRule($rule['instanceOf']), $rule);
 		}
@@ -41,7 +38,10 @@ class Dice {
 		if (isset($rule['substitutions'])) foreach($rule['substitutions'] as $key => $value) $rule['substitutions'][ltrim($key,  '\\')] = $value;
 
 		$dice = clone $this;
-		$dice->rules[ltrim(strtolower($name), '\\')] = array_replace_recursive($dice->getRule($name), $rule);
+        //Clear any existing instance or cache for this class
+        unset($dice->instances[$name], $dice->cache[$name]);
+
+        $dice->rules[ltrim(strtolower($name), '\\')] = array_replace_recursive($dice->getRule($name), $rule);
 
 		return $dice;
 	 }


### PR DESCRIPTION
- When adding a rule, caches should be cleared on the cloned container and not on the original container: some cached object may have side effects and if the original container is used again to retrieve such objects, the objects would be instantiated again and side effects would occur again.
- When adding multiple rules, the container should be cloned only once