### PR TITLE
Tag support

### DIFF
--- a/Dice.php
+++ b/Dice.php
@@ -10,6 +10,8 @@ class Dice {
 	const GLOBAL = 'Dice::GLOBAL';
 	const INSTANCE = 'Dice::INSTANCE';
 	const CHAIN_CALL = 'Dice::CHAIN_CALL';
+	const TAG = 'Dice::TAG';
+
 	/**
 	 * @var array $rules Rules which have been set using addRule()
 	 */
@@ -200,6 +202,7 @@ class Dice {
 				if (is_callable($param[self::INSTANCE])) return call_user_func($param[self::INSTANCE], ...$args);
 				else return $this->create($param[self::INSTANCE], array_merge($args, $share));
 			}
+			else if (isset($param[self::TAG])) return [iterator_to_array($this->getAll($param[self::TAG]))];
 			else if (isset($param[self::GLOBAL])) return $GLOBALS[$param[self::GLOBAL]];
 			else if (isset($param[self::CONSTANT])) return constant($param[self::CONSTANT]);
 			else foreach ($param as $name => $value) $param[$name] = $this->expand($value, $share);

--- a/tests/TagTest.php
+++ b/tests/TagTest.php
@@ -1,0 +1,45 @@
+<?php
+
+class TagTest extends DiceTest {
+
+    public function testNonexistentTag() {
+        $objects = $this->dice->getAll( 'a tag' );
+        $this->assertCount( 0, $objects );
+    }
+
+    public function testExistentTag() {
+        $dice = $this->dice->addRules(
+            [
+                A::class => [ 'tag' => 'ABC' ],
+                B::class => [ 'tag' => 'ABC' ],
+                C::class => [ 'tag' => 'ABC' ]
+            ]
+        );
+
+        $objects = iterator_to_array($dice->getAll('ABC'));
+
+        $this->assertCount(3, $objects );
+        $this->assertInstanceOf(A::class, $objects[0]);
+        $this->assertInstanceOf(B::class, $objects[1]);
+        $this->assertInstanceOf(C::class, $objects[2]);
+    }
+
+	public function testTagAddedTwice(){
+		$dice = $this->dice->addRules(
+			[
+				A::class => [ 'tag' => 'AB' ],
+				B::class => [ 'tag' => 'AB' ],
+			]
+		);
+
+		$dice = $dice->addRule(B::class, [ 'tag' => 'AB' ]);
+
+		$objects = iterator_to_array($dice->getAll('AB'));
+
+		$this->assertCount(2, $objects );
+		$this->assertInstanceOf(A::class, $objects[0]);
+		$this->assertInstanceOf(B::class, $objects[1]);
+	}
+
+
+}

--- a/tests/TagTest.php
+++ b/tests/TagTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Dice\Dice;
+
 class TagTest extends DiceTest {
 
     public function testNonexistentTag() {
@@ -39,6 +41,26 @@ class TagTest extends DiceTest {
 		$this->assertCount(2, $objects );
 		$this->assertInstanceOf(A::class, $objects[0]);
 		$this->assertInstanceOf(B::class, $objects[1]);
+	}
+
+	public function testTagParameter(){
+		$dice = $this->dice->addRules(
+			[
+				TestDispatcher::class => [
+					'constructParams' => [
+						Dice::TAG => 'Test Listeners'
+					]
+				],
+				EventListenerA::class => [ 'tag' => 'Test Listeners' ],
+				EventListenerB::class => [ 'tag' => 'Test Listeners' ]
+			]
+		);
+
+		$testListener = $dice->create(TestDispatcher::class);
+
+		$this->assertCount(2, $testListener->listeners);
+		$this->assertInstanceOf(EventListenerA::class, $testListener->listeners[0]);
+		$this->assertInstanceOf(EventListenerB::class, $testListener->listeners[1]);
 	}
 
 

--- a/tests/TestData/Tag.php
+++ b/tests/TestData/Tag.php
@@ -1,0 +1,11 @@
+<?php
+class EventListenerA {};
+class EventListenerB {};
+
+class TestDispatcher {
+	public $listeners;
+
+	public function __construct(array $listeners){
+		$this->listeners = $listeners;
+	}
+}


### PR DESCRIPTION
This patch add support for tagging classes and retrieving instances by tag.

This is useful when one has to retrieve collections of objects such as event listeners, strategies et cetera.

For example, using the container as service locator, given:
```
interface AnEventListener {}
class A implements AnEventListener {}
class B implements AnEventListener {}
```

During setup:
```
$dice->addRule( A::class, [ 'tag' => 'I']);
$dice->addRule( B::class, [ 'tag' => 'I']);
```

During event dispatch:
```
$instances = $dice->getAll('I');
```
Instead, using the container purely for dependency injection:
```
interface AnEventListener {
}

class EventListenerA implements AnEventListener {
}

class EventListenerB implements AnEventListener {
}

class Dispatcher {
	private $listeners;

	public function __construct(array $listeners){
		$this->listeners = $listeners;
	}
}

$dice = (new Dice\Dice())->addRules([
	Dispatcher::class => [
		Dispatcher::class => [
			'constructParams' => [
				Dice\Dice::TAG => 'Test Listeners'
			]
		],
		EventListenerA::class => [ 'tag' => 'Test Listeners' ],
		EventListenerB::class => [ 'tag' => 'Test Listeners' ]
	]
]);

$dispatcher = $dice->create(Dispatcher::class);
```

The tagged classes are not type-checked, as it would be impossible anyway to specify a typehint other than ``array``.