### PR TITLE
Fix issue #181, i.e. scalar constructParams passed in wrong order

### DIFF
--- a/Dice.php
+++ b/Dice.php
@@ -248,6 +248,7 @@ class Dice {
 					for ($i = 0; $i < count($args); $i++) {
 						if (call_user_func('is_' . $param->getType()->getName(), $args[$i])) {
 							$parameters[] = array_splice($args, $i, 1)[0];
+							break;
 						}
 					}
 				}


### PR DESCRIPTION
This fixes issue #181 (constructParams being applied in the wrong order) by adding a missing `break` statement in the loop that matches the appropriate scalar argument with the current paramInfo from the outer loop.