### PR TITLE
Fix issue where 'shareInstances' resolve but fail to propagate

### DIFF
--- a/Dice.php
+++ b/Dice.php
@@ -235,7 +235,7 @@ class Dice {
 					$parameters[] = $match;
 				}
 				// Do the same with $share
-				else if ($share && ($match = $this->matchParam($param, $class, $share)) !== false)  {
+				else if (($copy = $share) && ($match = $this->matchParam($param, $class, $copy)) !== false)  {
 					$parameters[] = $match;
 				}
 				// When nothing from $args or $share matches but a class is type hinted, create an instance to use, using a substitution if set

--- a/tests/ShareInstancesTest.php
+++ b/tests/ShareInstancesTest.php
@@ -18,7 +18,9 @@ class ShareInstancesTest extends DiceTest {
 		$this->assertInstanceOf('SharedInstanceTest1', $shareTest->share1);
 		$this->assertInstanceOf('SharedInstanceTest2', $shareTest->share2);
 
+		$this->assertSame($shareTest->shared, $shareTest->share1->shared);
 		$this->assertSame($shareTest->share1->shared, $shareTest->share2->shared);
+		$this->assertEquals($shareTest->shared->uniq, $shareTest->share1->shared->uniq);
 		$this->assertEquals($shareTest->share1->shared->uniq, $shareTest->share2->shared->uniq);
 
 	}
@@ -41,7 +43,9 @@ class ShareInstancesTest extends DiceTest {
 		$this->assertInstanceOf('SharedInstanceTest1', $shareTest->share1);
 		$this->assertInstanceOf('SharedInstanceTest2', $shareTest->share2);
 
+		$this->assertSame($shareTest->shared, $shareTest->share1->shared);
 		$this->assertSame($shareTest->share1->shared, $shareTest->share2->shared);
+		$this->assertEquals($shareTest->shared->uniq, $shareTest->share1->shared->uniq);
 		$this->assertEquals($shareTest->share1->shared->uniq, $shareTest->share2->shared->uniq);
 
 
@@ -72,15 +76,21 @@ class ShareInstancesTest extends DiceTest {
 		$this->assertInstanceOf('SharedInstanceTest1', $shareTest->share1);
 		$this->assertInstanceOf('SharedInstanceTest2', $shareTest->share2);
 
+		$this->assertSame($shareTest->shared, $shareTest->share1->shared);
 		$this->assertSame($shareTest->share1->shared, $shareTest->share2->shared);
+		$this->assertEquals($shareTest->shared->uniq, $shareTest->share1->shared->uniq);
 		$this->assertEquals($shareTest->share1->shared->uniq, $shareTest->share2->shared->uniq);
 
 
 		$shareTest2 = $dice->create('TestSharedInstancesTop');
+		$this->assertSame($shareTest2->shared, $shareTest2->share1->shared);
 		$this->assertSame($shareTest2->share1->shared, $shareTest2->share2->shared);
+		$this->assertEquals($shareTest2->shared->uniq, $shareTest2->share1->shared->uniq);
 		$this->assertEquals($shareTest2->share1->shared->uniq, $shareTest2->share2->shared->uniq);
 
+		$this->assertNotSame($shareTest->shared, $shareTest2->shared);
 		$this->assertNotSame($shareTest->share1->shared, $shareTest2->share2->shared);
+		$this->assertNotEquals($shareTest->shared->uniq, $shareTest2->shared->uniq);
 		$this->assertNotEquals($shareTest->share1->shared->uniq, $shareTest2->share2->shared->uniq);
 
 	}

--- a/tests/TestData/ShareInstances.php
+++ b/tests/TestData/ShareInstances.php
@@ -5,10 +5,12 @@
  * @license http:// www.opensource.org/licenses/bsd-license.php BSD License *
  * @version 3.0 */
 class TestSharedInstancesTop {
+	public $shared;
 	public $share1;
 	public $share2;
 
-	public function __construct(SharedInstanceTest1 $share1, SharedInstanceTest2 $share2) {
+	public function __construct(Shared $shared, SharedInstanceTest1 $share1, SharedInstanceTest2 $share2) {
+		$this->shared = $shared;
 		$this->share1 = $share1;
 		$this->share2 = $share2;
 	}


### PR DESCRIPTION
See issue #200.

The first commit updates the relevant tests to demonstrate the issue encountered in my own testing.

And from the second commit message:

> Because `$share` is passed by reference to `matchParam()`, and `matchParam()` removes matching objects from its `$search` array, instances may be removed from `$share` before it is passed to `expand()` or `create()`. Depending on the order of constructor parameters and the relative placement of `shareInstances` dependencies in the object tree, this may result in multiple instances of these dependencies being created.
>
> Fixed by passing a copy of the `$share` array to `matchParam()`.